### PR TITLE
modify sign in/ up field design

### DIFF
--- a/frontend/src/javascripts/components/atoms/buttons/toppage-btn.js
+++ b/frontend/src/javascripts/components/atoms/buttons/toppage-btn.js
@@ -2,13 +2,13 @@ import React from 'react'
 import { TopPageImgs } from '../../../constants/images'
 
 const TopPageBtn = ({ isSignIn, onClick }) => (
-  <a className="toppage-btn" onClick={onClick}>
+  <div className="toppage-btn" onClick={onClick}>
     {isSignIn ? (
       <img className="toppage-btn-img" src={TopPageImgs['signUp']} />
     ) : (
       <img className="toppage-btn-img" src={TopPageImgs['signIn']} />
     )}
-  </a>
+  </div>
 )
 
 export default TopPageBtn

--- a/frontend/src/javascripts/components/atoms/field.js
+++ b/frontend/src/javascripts/components/atoms/field.js
@@ -12,16 +12,31 @@ export default class Field extends Component {
       title: placeholder === 'title',
       description: placeholder === 'description',
       deadline: placeholder === 'deadline',
+      username: placeholder === 'NAME',
+      email: placeholder === 'EMAIL ADRESS',
+      password:
+        placeholder === 'PASSWORD' || placeholder === 'CONFIRM PASSWORD',
     })
     const inputClasses = classNames({
       title: placeholder === 'title',
       description: placeholder === 'description',
       deadline: placeholder === 'deadline',
+      username: placeholder === 'NAME',
+      email: placeholder === 'EMAIL ADRESS',
+      password:
+        placeholder === 'PASSWORD' || placeholder === 'CONFIRM PASSWORD',
+    })
+    const inputRadius = classNames({
+      'input-radius':
+        placeholder === 'NAME' ||
+        placeholder === 'EMAIL ADRESS' ||
+        placeholder === 'PASSWORD' ||
+        placeholder === 'CONFIRM PASSWORD',
     })
     return (
       <div className={fieldClasses}>
         <input
-          className={inputClasses}
+          className={`${inputClasses} ${inputRadius}`}
           placeholder={placeholder}
           type={type}
           {...input}

--- a/frontend/src/stylesheets/_button.scss
+++ b/frontend/src/stylesheets/_button.scss
@@ -1,10 +1,11 @@
 @import "initializer";
 
 .toppage-btn {
-  display: block;
   position: fixed;
   top: 10px;
   right: 10px;
+  width: 180px;
+  height: 100px;
   cursor: pointer;
 
   .toppage-btn-img {

--- a/frontend/src/stylesheets/common.scss
+++ b/frontend/src/stylesheets/common.scss
@@ -72,7 +72,7 @@ input {
   text-align: left;
   border: none;
   border-bottom: solid 1px #ddd;
-  color: #fff;
-  background-color: $bg-common-color;
+  color: #fff !important;
+  background-color: $bg-common-color !important;
   padding: 0 5px;
 }

--- a/frontend/src/stylesheets/field.scss
+++ b/frontend/src/stylesheets/field.scss
@@ -10,8 +10,14 @@
   font-family: orator-std, monospace;
   font-style: normal;
   font-weight: 300;
+
+  .input-radius {
+    border-radius: 20px;
+    text-align: center
+  }
     
   .input-error {
+    margin: 5px auto;
     height: 15px;
     line-height: 15px;
     font-size: 12px;
@@ -28,6 +34,11 @@
 .description {
   width: 250px !important;
   height: 40px !important;
+}
+.email, .username, .password {
+  margin: 10px auto;
+  width: 200px !important;
+  height: 20px !important;
 }
 .has-danger {
 }


### PR DESCRIPTION
## 概要
デザインfix

## 関連Issue


## 詳細
formのscssを整理した関係でデザイン崩れしていたので修正
<img width="1280" alt="2018-12-10 1 04 09" src="https://user-images.githubusercontent.com/39118010/49699678-83c56800-fc17-11e8-86d0-5f985baefc9b.png">


## 対象ページ

## 特にレビューしてほしいところ

## その他
sing up + のフォームの切り替えができない状況です（onclick が機能してないっぽい）
その辺のソースコード確認してもらえると助かります。

